### PR TITLE
Rework crypto API

### DIFF
--- a/examples/arc_seal.rs
+++ b/examples/arc_seal.rs
@@ -9,8 +9,9 @@
  */
 
 use mail_auth::{
-    arc::ArcSet, common::headers::HeaderWriter, AuthenticatedMessage, AuthenticationResults,
-    PrivateKey, Resolver,
+    arc::ArcSet,
+    common::{crypto::PrivateKey, headers::HeaderWriter},
+    AuthenticatedMessage, AuthenticationResults, Resolver,
 };
 
 const TEST_MESSAGE: &str = include_str!("../resources/arc/001.txt");

--- a/examples/arc_seal.rs
+++ b/examples/arc_seal.rs
@@ -10,9 +10,10 @@
 
 use mail_auth::{
     arc::ArcSet,
-    common::{crypto::PrivateKey, headers::HeaderWriter},
+    common::{crypto::RsaKey, headers::HeaderWriter},
     AuthenticatedMessage, AuthenticationResults, Resolver,
 };
+use sha2::Sha256;
 
 const TEST_MESSAGE: &str = include_str!("../resources/arc/001.txt");
 
@@ -52,7 +53,7 @@ async fn main() {
     // Seal message
     if arc_result.can_be_sealed() {
         // Seal the e-mail message using RSA-SHA256
-        let pk_rsa = PrivateKey::from_rsa_pkcs1_pem(RSA_PRIVATE_KEY).unwrap();
+        let pk_rsa = RsaKey::<Sha256>::from_rsa_pkcs1_pem(RSA_PRIVATE_KEY).unwrap();
         let arc_set = ArcSet::new(&auth_results)
             .domain("example.org")
             .selector("default")

--- a/examples/dkim_sign.rs
+++ b/examples/dkim_sign.rs
@@ -9,10 +9,11 @@
  */
 
 use mail_auth::{
-    common::{crypto::PrivateKey, headers::HeaderWriter},
+    common::{crypto::Ed25519Key, crypto::RsaKey, headers::HeaderWriter},
     dkim::Signature,
 };
 use mail_parser::decoders::base64::base64_decode;
+use sha2::Sha256;
 
 const RSA_PRIVATE_KEY: &str = r#"-----BEGIN RSA PRIVATE KEY-----
 MIICXwIBAAKBgQDwIRP/UC3SBsEmGqZ9ZJW3/DkMoGeLnQg1fWn7/zYtIxN2SnFC
@@ -42,7 +43,7 @@ I'm going to need those TPS reports ASAP. So, if you could do that, that'd be gr
 
 fn main() {
     // Sign an e-mail message using RSA-SHA256
-    let pk_rsa = PrivateKey::from_rsa_pkcs1_pem(RSA_PRIVATE_KEY).unwrap();
+    let pk_rsa = RsaKey::<Sha256>::from_rsa_pkcs1_pem(RSA_PRIVATE_KEY).unwrap();
     let signature_rsa = Signature::new()
         .headers(["From", "To", "Subject"])
         .domain("example.com")
@@ -51,7 +52,7 @@ fn main() {
         .unwrap();
 
     // Sign an e-mail message using ED25519-SHA256
-    let pk_ed = PrivateKey::from_ed25519(
+    let pk_ed = Ed25519Key::from_bytes(
         &base64_decode(ED25519_PUBLIC_KEY.as_bytes()).unwrap(),
         &base64_decode(ED25519_PRIVATE_KEY.as_bytes()).unwrap(),
     )

--- a/examples/dkim_sign.rs
+++ b/examples/dkim_sign.rs
@@ -8,7 +8,10 @@
  * except according to those terms.
  */
 
-use mail_auth::{common::headers::HeaderWriter, dkim::Signature, PrivateKey};
+use mail_auth::{
+    common::{crypto::PrivateKey, headers::HeaderWriter},
+    dkim::Signature,
+};
 use mail_parser::decoders::base64::base64_decode;
 
 const RSA_PRIVATE_KEY: &str = r#"-----BEGIN RSA PRIVATE KEY-----

--- a/src/arc/headers.rs
+++ b/src/arc/headers.rs
@@ -11,8 +11,8 @@
 use std::io;
 
 use crate::{
-    common::headers::HeaderWriter,
-    dkim::{Algorithm, Canonicalization},
+    common::{crypto::Algorithm, headers::HeaderWriter},
+    dkim::Canonicalization,
     AuthenticationResults,
 };
 

--- a/src/arc/mod.rs
+++ b/src/arc/mod.rs
@@ -16,8 +16,8 @@ pub mod verify;
 use std::borrow::Cow;
 
 use crate::{
-    common::{headers::Header, verify::VerifySignature},
-    dkim::{Algorithm, Canonicalization},
+    common::{crypto::Algorithm, headers::Header, verify::VerifySignature},
+    dkim::Canonicalization,
     ArcOutput, AuthenticationResults, DkimResult,
 };
 

--- a/src/arc/parse.rs
+++ b/src/arc/parse.rs
@@ -11,8 +11,8 @@
 use mail_parser::decoders::base64::base64_decode_stream;
 
 use crate::{
-    common::parse::TagParser,
-    dkim::{parse::SignatureParser, Algorithm, Canonicalization},
+    common::{crypto::Algorithm, parse::TagParser},
+    dkim::{parse::SignatureParser, Canonicalization},
     Error,
 };
 

--- a/src/arc/seal.rs
+++ b/src/arc/seal.rs
@@ -17,8 +17,8 @@ use sha1::Digest;
 use sha2::Sha256;
 
 use crate::{
-    dkim::{Algorithm, Canonicalization},
-    ArcOutput, AuthenticatedMessage, AuthenticationResults, DkimResult, Error, PrivateKey,
+    common::crypto::Algorithm, dkim::Canonicalization, ArcOutput, AuthenticatedMessage,
+    AuthenticationResults, DkimResult, Error, PrivateKey,
 };
 
 use super::{ArcSet, ChainValidation, Seal, Signature};

--- a/src/arc/seal.rs
+++ b/src/arc/seal.rs
@@ -10,15 +10,12 @@
 
 use std::{borrow::Cow, io::Write, time::SystemTime};
 
-use ed25519_dalek::Signer;
 use mail_builder::encoders::base64::base64_encode;
-use rsa::PaddingScheme;
-use sha1::Digest;
-use sha2::Sha256;
+use sha2::{Digest, Sha256};
 
 use crate::{
-    common::crypto::Algorithm, dkim::Canonicalization, ArcOutput, AuthenticatedMessage,
-    AuthenticationResults, DkimResult, Error, PrivateKey,
+    common::crypto::SigningKey, dkim::Canonicalization, ArcOutput, AuthenticatedMessage,
+    AuthenticationResults, DkimResult, Error,
 };
 
 use super::{ArcSet, ChainValidation, Seal, Signature};
@@ -36,20 +33,15 @@ impl<'x> ArcSet<'x> {
         mut self,
         message: &'x AuthenticatedMessage<'x>,
         arc_output: &ArcOutput,
-        with_key: &PrivateKey,
+        with_key: &impl SigningKey<Hasher = Sha256>,
     ) -> crate::Result<Self> {
         if !arc_output.can_be_sealed() {
             return Err(Error::ARCInvalidCV);
         }
 
         // Set a=
-        if let PrivateKey::Ed25519(_) = with_key {
-            self.signature.a = Algorithm::Ed25519Sha256;
-            self.seal.a = Algorithm::Ed25519Sha256;
-        } else {
-            self.signature.a = Algorithm::RsaSha256;
-            self.seal.a = Algorithm::RsaSha256;
-        }
+        self.signature.a = with_key.algorithm();
+        self.seal.a = with_key.algorithm();
 
         // Set i= and cv=
         if arc_output.set.is_empty() {
@@ -67,8 +59,8 @@ impl<'x> ArcSet<'x> {
         }
 
         // Create hashes
-        let mut body_hasher = Sha256::new();
-        let mut header_hasher = Sha256::new();
+        let mut body_hasher = with_key.hasher();
+        let mut header_hasher = with_key.hasher();
 
         // Canonicalize headers and body
         let (body_len, signed_headers) =
@@ -100,17 +92,7 @@ impl<'x> ArcSet<'x> {
         self.signature.write(&mut header_hasher, false)?;
 
         // Sign
-        let b = match with_key {
-            PrivateKey::Rsa(private_key) => private_key
-                .sign(
-                    PaddingScheme::new_pkcs1v15_sign::<Sha256>(),
-                    &header_hasher.finalize(),
-                )
-                .map_err(|err| Error::CryptoError(err.to_string()))?,
-            PrivateKey::Ed25519(key_pair) => {
-                key_pair.sign(&header_hasher.finalize()).to_bytes().to_vec()
-            }
-        };
+        let b = with_key.sign(&header_hasher.finalize())?;
         self.signature.b = base64_encode(&b)?;
 
         // Hash ARC chain
@@ -135,17 +117,7 @@ impl<'x> ArcSet<'x> {
         self.seal.write(&mut header_hasher, false)?;
 
         // Seal
-        let b = match with_key {
-            PrivateKey::Rsa(private_key) => private_key
-                .sign(
-                    PaddingScheme::new_pkcs1v15_sign::<Sha256>(),
-                    &header_hasher.finalize(),
-                )
-                .map_err(|err| Error::CryptoError(err.to_string()))?,
-            PrivateKey::Ed25519(key_pair) => {
-                key_pair.sign(&header_hasher.finalize()).to_bytes().to_vec()
-            }
-        };
+        let b = with_key.sign(&header_hasher.finalize())?;
         self.seal.b = base64_encode(&b)?;
 
         Ok(self)
@@ -242,12 +214,17 @@ mod test {
     use std::time::{Duration, Instant};
 
     use mail_parser::decoders::base64::base64_decode;
+    use sha2::Sha256;
 
     use crate::{
         arc::ArcSet,
-        common::{headers::HeaderWriter, parse::TxtRecordParser},
+        common::{
+            crypto::{Ed25519Key, RsaKey, SigningKey},
+            headers::HeaderWriter,
+            parse::TxtRecordParser,
+        },
         dkim::{DomainKey, Signature},
-        AuthenticatedMessage, AuthenticationResults, DkimResult, PrivateKey, Resolver,
+        AuthenticatedMessage, AuthenticationResults, DkimResult, Resolver,
     };
 
     const RSA_PRIVATE_KEY: &str = r#"-----BEGIN RSA PRIVATE KEY-----
@@ -303,8 +280,8 @@ GMot/L2x0IYyMLAz6oLWh2hm7zwtb0CgOrPo1ke44hFYnfc=
         );
 
         // Create private keys
-        let pk_rsa = PrivateKey::from_rsa_pkcs1_pem(RSA_PRIVATE_KEY).unwrap();
-        let pk_ed = PrivateKey::from_ed25519(
+        let pk_rsa = RsaKey::<Sha256>::from_rsa_pkcs1_pem(RSA_PRIVATE_KEY).unwrap();
+        let pk_ed = Ed25519Key::from_bytes(
             &base64_decode(ED25519_PUBLIC_KEY.rsplit_once("p=").unwrap().1.as_bytes()).unwrap(),
             &base64_decode(ED25519_PRIVATE_KEY.as_bytes()).unwrap(),
         )
@@ -336,7 +313,7 @@ GMot/L2x0IYyMLAz6oLWh2hm7zwtb0CgOrPo1ke44hFYnfc=
         raw_message: &str,
         d: &str,
         s: &str,
-        pk: &PrivateKey,
+        pk: &impl SigningKey<Hasher = Sha256>,
     ) -> String {
         let message = AuthenticatedMessage::parse(raw_message.as_bytes()).unwrap();
         let dkim_result = resolver.verify_dkim(&message).await;

--- a/src/arc/seal.rs
+++ b/src/arc/seal.rs
@@ -110,7 +110,6 @@ impl<'x> ArcSet<'x> {
             PrivateKey::Ed25519(key_pair) => {
                 key_pair.sign(&header_hasher.finalize()).to_bytes().to_vec()
             }
-            PrivateKey::None => return Err(Error::MissingParameters),
         };
         self.signature.b = base64_encode(&b)?;
 
@@ -146,7 +145,6 @@ impl<'x> ArcSet<'x> {
             PrivateKey::Ed25519(key_pair) => {
                 key_pair.sign(&header_hasher.finalize()).to_bytes().to_vec()
             }
-            PrivateKey::None => return Err(Error::MissingParameters),
         };
         self.seal.b = base64_encode(&b)?;
 

--- a/src/arc/verify.rs
+++ b/src/arc/verify.rs
@@ -14,8 +14,12 @@ use sha1::Sha1;
 use sha2::Sha256;
 
 use crate::{
-    common::{headers::Header, verify::VerifySignature},
-    dkim::{verify::Verifier, Algorithm, Canonicalization, DomainKey, HashAlgorithm},
+    common::{
+        crypto::{Algorithm, HashAlgorithm},
+        headers::Header,
+        verify::VerifySignature,
+    },
+    dkim::{verify::Verifier, Canonicalization, DomainKey},
     ArcOutput, AuthenticatedMessage, DkimResult, Error, Resolver,
 };
 

--- a/src/common/crypto.rs
+++ b/src/common/crypto.rs
@@ -1,0 +1,54 @@
+use rsa::{RsaPrivateKey, pkcs1::DecodeRsaPrivateKey};
+
+use crate::Error;
+
+#[derive(Debug)]
+pub enum PrivateKey {
+    Rsa(RsaPrivateKey),
+    Ed25519(ed25519_dalek::Keypair),
+}
+
+impl PrivateKey {
+    /// Creates a new RSA private key from a PKCS1 PEM string.
+    pub fn from_rsa_pkcs1_pem(private_key_pem: &str) -> crate::Result<Self> {
+        Ok(PrivateKey::Rsa(
+            RsaPrivateKey::from_pkcs1_pem(private_key_pem)
+                .map_err(|err| Error::CryptoError(err.to_string()))?,
+        ))
+    }
+
+    /// Creates a new RSA private key from a PKCS1 binary slice.
+    pub fn from_rsa_pkcs1_der(private_key_bytes: &[u8]) -> crate::Result<Self> {
+        Ok(PrivateKey::Rsa(
+            RsaPrivateKey::from_pkcs1_der(private_key_bytes)
+                .map_err(|err| Error::CryptoError(err.to_string()))?,
+        ))
+    }
+
+    /// Creates an Ed25519 private key
+    pub fn from_ed25519(public_key_bytes: &[u8], private_key_bytes: &[u8]) -> crate::Result<Self> {
+        Ok(PrivateKey::Ed25519(ed25519_dalek::Keypair {
+            public: ed25519_dalek::PublicKey::from_bytes(public_key_bytes)
+                .map_err(|err| Error::CryptoError(err.to_string()))?,
+            secret: ed25519_dalek::SecretKey::from_bytes(private_key_bytes)
+                .map_err(|err| Error::CryptoError(err.to_string()))?,
+        }))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u64)]
+pub enum HashAlgorithm {
+    Sha1 = R_HASH_SHA1,
+    Sha256 = R_HASH_SHA256,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Algorithm {
+    RsaSha1,
+    RsaSha256,
+    Ed25519Sha256,
+}
+
+pub(crate) const R_HASH_SHA1: u64 = 0x01;
+pub(crate) const R_HASH_SHA256: u64 = 0x02;

--- a/src/common/crypto.rs
+++ b/src/common/crypto.rs
@@ -1,38 +1,113 @@
-use rsa::{RsaPrivateKey, pkcs1::DecodeRsaPrivateKey};
+use std::{io, marker::PhantomData};
 
-use crate::Error;
+use ed25519_dalek::Signer;
+use rsa::{
+    pkcs1::DecodeRsaPrivateKey,
+    pkcs8::{AssociatedOid, ObjectIdentifier},
+    PaddingScheme, RsaPrivateKey,
+};
+use sha1::{digest::Output, Sha1};
+use sha2::{digest::Digest, Sha256};
 
-#[derive(Debug)]
-pub enum PrivateKey {
-    Rsa(RsaPrivateKey),
-    Ed25519(ed25519_dalek::Keypair),
+use crate::{Error, Result};
+
+pub trait SigningKey {
+    type Hasher: Digest + AssociatedOid + io::Write;
+
+    fn sign(&self, data: &Output<Self::Hasher>) -> Result<Vec<u8>>;
+
+    fn hasher(&self) -> Self::Hasher {
+        Self::Hasher::new()
+    }
+
+    fn algorithm(&self) -> Algorithm;
 }
 
-impl PrivateKey {
+#[derive(Debug)]
+pub struct RsaKey<T> {
+    inner: RsaPrivateKey,
+    padding: PhantomData<T>,
+}
+
+impl<T: Digest + AssociatedOid + io::Write> RsaKey<T> {
     /// Creates a new RSA private key from a PKCS1 PEM string.
-    pub fn from_rsa_pkcs1_pem(private_key_pem: &str) -> crate::Result<Self> {
-        Ok(PrivateKey::Rsa(
-            RsaPrivateKey::from_pkcs1_pem(private_key_pem)
-                .map_err(|err| Error::CryptoError(err.to_string()))?,
-        ))
+    pub fn from_rsa_pkcs1_pem(private_key_pem: &str) -> Result<Self> {
+        let inner = RsaPrivateKey::from_pkcs1_pem(private_key_pem)
+            .map_err(|err| Error::CryptoError(err.to_string()))?;
+
+        Ok(RsaKey {
+            inner,
+            padding: PhantomData,
+        })
     }
 
     /// Creates a new RSA private key from a PKCS1 binary slice.
-    pub fn from_rsa_pkcs1_der(private_key_bytes: &[u8]) -> crate::Result<Self> {
-        Ok(PrivateKey::Rsa(
-            RsaPrivateKey::from_pkcs1_der(private_key_bytes)
-                .map_err(|err| Error::CryptoError(err.to_string()))?,
-        ))
+    pub fn from_rsa_pkcs1_der(private_key_bytes: &[u8]) -> Result<Self> {
+        let inner = RsaPrivateKey::from_pkcs1_der(private_key_bytes)
+            .map_err(|err| Error::CryptoError(err.to_string()))?;
+
+        Ok(RsaKey {
+            inner,
+            padding: PhantomData,
+        })
+    }
+}
+
+impl SigningKey for RsaKey<Sha1> {
+    type Hasher = Sha1;
+
+    fn sign(&self, data: &Output<Self::Hasher>) -> Result<Vec<u8>> {
+        self.inner
+            .sign(PaddingScheme::new_pkcs1v15_sign::<Self::Hasher>(), data)
+            .map_err(|err| Error::CryptoError(err.to_string()))
     }
 
+    fn algorithm(&self) -> Algorithm {
+        Algorithm::RsaSha1
+    }
+}
+
+impl SigningKey for RsaKey<Sha256> {
+    type Hasher = Sha256;
+
+    fn sign(&self, data: &Output<Self::Hasher>) -> Result<Vec<u8>> {
+        self.inner
+            .sign(PaddingScheme::new_pkcs1v15_sign::<Self::Hasher>(), data)
+            .map_err(|err| Error::CryptoError(err.to_string()))
+    }
+
+    fn algorithm(&self) -> Algorithm {
+        Algorithm::RsaSha256
+    }
+}
+
+pub struct Ed25519Key {
+    inner: ed25519_dalek::Keypair,
+}
+
+impl Ed25519Key {
     /// Creates an Ed25519 private key
-    pub fn from_ed25519(public_key_bytes: &[u8], private_key_bytes: &[u8]) -> crate::Result<Self> {
-        Ok(PrivateKey::Ed25519(ed25519_dalek::Keypair {
-            public: ed25519_dalek::PublicKey::from_bytes(public_key_bytes)
-                .map_err(|err| Error::CryptoError(err.to_string()))?,
-            secret: ed25519_dalek::SecretKey::from_bytes(private_key_bytes)
-                .map_err(|err| Error::CryptoError(err.to_string()))?,
-        }))
+    pub fn from_bytes(public_key_bytes: &[u8], private_key_bytes: &[u8]) -> crate::Result<Self> {
+        Ok(Self {
+            inner: ed25519_dalek::Keypair {
+                public: ed25519_dalek::PublicKey::from_bytes(public_key_bytes)
+                    .map_err(|err| Error::CryptoError(err.to_string()))?,
+                secret: ed25519_dalek::SecretKey::from_bytes(private_key_bytes)
+                    .map_err(|err| Error::CryptoError(err.to_string()))?,
+            },
+        })
+    }
+}
+
+impl SigningKey for Ed25519Key {
+    type Hasher = Sha256;
+
+    fn sign(&self, data: &Output<Self::Hasher>) -> Result<Vec<u8>> {
+        Ok(self.inner.sign(data.as_ref()).to_bytes().to_vec())
+    }
+
+    fn algorithm(&self) -> Algorithm {
+        Algorithm::Ed25519Sha256
     }
 }
 
@@ -41,6 +116,18 @@ impl PrivateKey {
 pub enum HashAlgorithm {
     Sha1 = R_HASH_SHA1,
     Sha256 = R_HASH_SHA256,
+}
+
+impl TryFrom<&ObjectIdentifier> for HashAlgorithm {
+    type Error = Error;
+
+    fn try_from(oid: &ObjectIdentifier) -> Result<Self> {
+        match oid {
+            oid if oid == &Sha256::OID => Ok(HashAlgorithm::Sha256),
+            oid if oid == &Sha1::OID => Ok(HashAlgorithm::Sha1),
+            _ => Err(Error::CryptoError("Unsupported hash algorithm".to_string())),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/common/message.rs
+++ b/src/common/message.rs
@@ -12,11 +12,7 @@ use mail_parser::{parsers::MessageStream, HeaderValue};
 use sha1::Sha1;
 use sha2::Sha256;
 
-use crate::{
-    arc,
-    dkim::{self, HashAlgorithm},
-    AuthenticatedMessage,
-};
+use crate::{arc, common::crypto::HashAlgorithm, dkim, AuthenticatedMessage};
 
 use super::headers::{AuthenticatedHeader, Header, HeaderParser};
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod auth_results;
 pub mod base32;
+pub mod crypto;
 pub mod headers;
 pub mod lru;
 pub mod message;

--- a/src/common/verify.rs
+++ b/src/common/verify.rs
@@ -13,7 +13,8 @@ use sha1::Sha1;
 use sha2::Sha256;
 
 use crate::{
-    dkim::{Algorithm, DomainKey, PublicKey},
+    common::crypto::Algorithm,
+    dkim::{DomainKey, PublicKey},
     Error,
 };
 

--- a/src/dkim/mod.rs
+++ b/src/dkim/mod.rs
@@ -13,7 +13,12 @@ use std::borrow::Cow;
 use rsa::RsaPublicKey;
 
 use crate::{
-    arc::Set, common::verify::VerifySignature, ArcOutput, DkimOutput, DkimResult, Error, Version,
+    arc::Set,
+    common::{
+        crypto::{Algorithm, HashAlgorithm},
+        verify::VerifySignature,
+    },
+    ArcOutput, DkimOutput, DkimResult, Error, Version,
 };
 
 pub mod canonicalize;
@@ -26,20 +31,6 @@ pub mod verify;
 pub enum Canonicalization {
     Relaxed,
     Simple,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u64)]
-pub enum HashAlgorithm {
-    Sha1 = R_HASH_SHA1,
-    Sha256 = R_HASH_SHA256,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Algorithm {
-    RsaSha1,
-    RsaSha256,
-    Ed25519Sha256,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
@@ -96,8 +87,6 @@ pub struct Atps {
     pub(crate) d: Option<String>,
 }
 
-pub(crate) const R_HASH_SHA1: u64 = 0x01;
-pub(crate) const R_HASH_SHA256: u64 = 0x02;
 pub(crate) const R_SVC_ALL: u64 = 0x04;
 pub(crate) const R_SVC_EMAIL: u64 = 0x08;
 pub(crate) const R_FLAG_TESTING: u64 = 0x10;

--- a/src/dkim/parse.rs
+++ b/src/dkim/parse.rs
@@ -479,12 +479,14 @@ mod test {
     use rsa::{pkcs8::DecodePublicKey, RsaPublicKey};
 
     use crate::{
-        common::parse::TxtRecordParser,
+        common::{
+            crypto::{Algorithm, R_HASH_SHA1, R_HASH_SHA256},
+            parse::TxtRecordParser,
+        },
         dkim::{
-            Algorithm, Canonicalization, DomainKey, DomainKeyReport, PublicKey, Signature, Version,
-            RR_DNS, RR_EXPIRATION, RR_OTHER, RR_POLICY, RR_SIGNATURE, RR_UNKNOWN_TAG,
-            RR_VERIFICATION, R_FLAG_MATCH_DOMAIN, R_FLAG_TESTING, R_HASH_SHA1, R_HASH_SHA256,
-            R_SVC_ALL, R_SVC_EMAIL,
+            Canonicalization, DomainKey, DomainKeyReport, PublicKey, Signature, Version, RR_DNS,
+            RR_EXPIRATION, RR_OTHER, RR_POLICY, RR_SIGNATURE, RR_UNKNOWN_TAG, RR_VERIFICATION,
+            R_FLAG_MATCH_DOMAIN, R_FLAG_TESTING, R_SVC_ALL, R_SVC_EMAIL,
         },
     };
 

--- a/src/dkim/sign.rs
+++ b/src/dkim/sign.rs
@@ -12,41 +12,13 @@ use std::{borrow::Cow, io, time::SystemTime};
 
 use ed25519_dalek::Signer;
 use mail_builder::encoders::base64::base64_encode;
-use rsa::{pkcs1::DecodeRsaPrivateKey, pkcs8::AssociatedOid, PaddingScheme, RsaPrivateKey};
+use rsa::{pkcs8::AssociatedOid, PaddingScheme};
 use sha1::Sha1;
 use sha2::{Digest, Sha256};
 
 use crate::{Error, PrivateKey};
 
 use super::{Algorithm, Canonicalization, HashAlgorithm, Signature};
-
-impl PrivateKey {
-    /// Creates a new RSA private key from a PKCS1 PEM string.
-    pub fn from_rsa_pkcs1_pem(private_key_pem: &str) -> crate::Result<Self> {
-        Ok(PrivateKey::Rsa(
-            RsaPrivateKey::from_pkcs1_pem(private_key_pem)
-                .map_err(|err| Error::CryptoError(err.to_string()))?,
-        ))
-    }
-
-    /// Creates a new RSA private key from a PKCS1 binary slice.
-    pub fn from_rsa_pkcs1_der(private_key_bytes: &[u8]) -> crate::Result<Self> {
-        Ok(PrivateKey::Rsa(
-            RsaPrivateKey::from_pkcs1_der(private_key_bytes)
-                .map_err(|err| Error::CryptoError(err.to_string()))?,
-        ))
-    }
-
-    /// Creates an Ed25519 private key
-    pub fn from_ed25519(public_key_bytes: &[u8], private_key_bytes: &[u8]) -> crate::Result<Self> {
-        Ok(PrivateKey::Ed25519(ed25519_dalek::Keypair {
-            public: ed25519_dalek::PublicKey::from_bytes(public_key_bytes)
-                .map_err(|err| Error::CryptoError(err.to_string()))?,
-            secret: ed25519_dalek::SecretKey::from_bytes(private_key_bytes)
-                .map_err(|err| Error::CryptoError(err.to_string()))?,
-        }))
-    }
-}
 
 impl<'x> Signature<'x> {
     /// Creates a new DKIM signature.

--- a/src/dkim/sign.rs
+++ b/src/dkim/sign.rs
@@ -80,7 +80,6 @@ impl<'x> Signature<'x> {
                     self.a = Algorithm::RsaSha256;
                     self.sign_::<Sha256>(message, with_key, now)
                 }
-                _ => Err(Error::IncompatibleAlgorithms),
             }
         } else {
             Err(Error::MissingParameters)
@@ -125,7 +124,6 @@ impl<'x> Signature<'x> {
             PrivateKey::Ed25519(key_pair) => {
                 key_pair.sign(&header_hasher.finalize()).to_bytes().to_vec()
             }
-            PrivateKey::None => return Err(Error::MissingParameters),
         };
 
         // Encode

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 //!
 //! ```rust
 //!     // Sign an e-mail message using RSA-SHA256
-//!     let pk_rsa = PrivateKey::from_rsa_pkcs1_pem(RSA_PRIVATE_KEY).unwrap();
+//!     let pk_rsa = RsaKey::<Sha256>::from_rsa_pkcs1_pem(RSA_PRIVATE_KEY).unwrap();
 //!     let signature_rsa = Signature::new()
 //!         .headers(["From", "To", "Subject"])
 //!         .domain("example.com")
@@ -69,7 +69,7 @@
 //!         .unwrap();
 //!
 //!     // Sign an e-mail message using ED25519-SHA256
-//!     let pk_ed = PrivateKey::from_ed25519(
+//!     let pk_ed = Ed25519Key::from_bytes(
 //!         &base64_decode(ED25519_PUBLIC_KEY.as_bytes()).unwrap(),
 //!         &base64_decode(ED25519_PRIVATE_KEY.as_bytes()).unwrap(),
 //!     )
@@ -78,6 +78,7 @@
 //!         .headers(["From", "To", "Subject"])
 //!         .domain("example.com")
 //!         .selector("default-ed")
+//!         .algorithm(Algorithm::Ed25519Sha256)
 //!         .sign(RFC5322_MESSAGE.as_bytes(), &pk_ed)
 //!         .unwrap();
 //!
@@ -127,7 +128,7 @@
 //!     // Seal message
 //!     if arc_result.can_be_sealed() {
 //!         // Seal the e-mail message using RSA-SHA256
-//!         let pk_rsa = PrivateKey::from_rsa_pkcs1_pem(RSA_PRIVATE_KEY).unwrap();
+//!         let pk_rsa = RsaKey::<Sha256>::from_rsa_pkcs1_pem(RSA_PRIVATE_KEY).unwrap();
 //!         let arc_set = ArcSet::new(&auth_results)
 //!             .domain("example.org")
 //!             .selector("default")
@@ -262,11 +263,7 @@ use std::{
 };
 
 use arc::Set;
-use common::{
-    crypto::{HashAlgorithm, PrivateKey},
-    headers::Header,
-    lru::LruCache,
-};
+use common::{crypto::HashAlgorithm, headers::Header, lru::LruCache};
 use dkim::{Atps, Canonicalization, DomainKey, DomainKeyReport};
 use dmarc::Dmarc;
 use spf::{Macro, Spf};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,8 +280,8 @@ pub mod spf;
 pub enum PrivateKey {
     Rsa(RsaPrivateKey),
     Ed25519(ed25519_dalek::Keypair),
-    None,
 }
+
 #[derive(Debug)]
 pub struct Resolver {
     pub(crate) resolver: TokioAsyncResolver,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,10 +262,13 @@ use std::{
 };
 
 use arc::Set;
-use common::{headers::Header, lru::LruCache};
-use dkim::{Atps, Canonicalization, DomainKey, DomainKeyReport, HashAlgorithm};
+use common::{
+    crypto::{HashAlgorithm, PrivateKey},
+    headers::Header,
+    lru::LruCache,
+};
+use dkim::{Atps, Canonicalization, DomainKey, DomainKeyReport};
 use dmarc::Dmarc;
-use rsa::RsaPrivateKey;
 use spf::{Macro, Spf};
 use trust_dns_resolver::{proto::op::ResponseCode, TokioAsyncResolver};
 
@@ -275,12 +278,6 @@ pub mod dkim;
 pub mod dmarc;
 pub mod report;
 pub mod spf;
-
-#[derive(Debug)]
-pub enum PrivateKey {
-    Rsa(RsaPrivateKey),
-    Ed25519(ed25519_dalek::Keypair),
-}
 
 #[derive(Debug)]
 pub struct Resolver {


### PR DESCRIPTION
Here's my initial work towards fixing #1.

I feel like the DKIM signing API is a bit strange? It feels mistyped that the input for `Signature::sign()` is a `Signature` and the output is, too. Notably in this case `Signature` has an `a` field for `algorithm` (I would probably opt to make the field names expanded idiomatic snake_case and add comments to clarify the on-the-wire short name) which gets a default value and then there's some potentially surprising/weird logic to resolve that with the type of the key passed in. In my current version I've turned a mismatch into a run-time error, but this seems like the kind of thing that could be prevented by using different types for input and output.

I'm also confused about the strategy for the public API. All the internal modules seem public, which means that by moving `PrivateKey` into `common::crypto` it becomes a bit harder to reach for, but so far there are no `pub use` declarations in sight. (I also find the style of keeping struct definitions in different modules than `impl` blocks relatively hard to navigate.)

Curious to hear your feedback!