### PR TITLE
Use object-safe VerifyingKey trait instead of PublicKey enum

### DIFF
--- a/src/arc/mod.rs
+++ b/src/arc/mod.rs
@@ -82,37 +82,37 @@ impl Default for ChainValidation {
 }
 
 impl<'x> VerifySignature for Signature<'x> {
-    fn b(&self) -> &[u8] {
+    fn signature(&self) -> &[u8] {
         &self.b
     }
 
-    fn a(&self) -> Algorithm {
+    fn algorithm(&self) -> Algorithm {
         self.a
     }
 
-    fn s(&self) -> &str {
+    fn selector(&self) -> &str {
         &self.s
     }
 
-    fn d(&self) -> &str {
+    fn domain(&self) -> &str {
         &self.d
     }
 }
 
 impl<'x> VerifySignature for Seal<'x> {
-    fn b(&self) -> &[u8] {
+    fn signature(&self) -> &[u8] {
         &self.b
     }
 
-    fn a(&self) -> Algorithm {
+    fn algorithm(&self) -> Algorithm {
         self.a
     }
 
-    fn s(&self) -> &str {
+    fn selector(&self) -> &str {
         &self.s
     }
 
-    fn d(&self) -> &str {
+    fn domain(&self) -> &str {
         &self.d
     }
 }

--- a/src/common/verify.rs
+++ b/src/common/verify.rs
@@ -11,17 +11,17 @@
 use crate::{common::crypto::Algorithm, dkim::DomainKey};
 
 pub(crate) trait VerifySignature {
-    fn s(&self) -> &str;
+    fn selector(&self) -> &str;
 
-    fn d(&self) -> &str;
+    fn domain(&self) -> &str;
 
-    fn b(&self) -> &[u8];
+    fn signature(&self) -> &[u8];
 
-    fn a(&self) -> Algorithm;
+    fn algorithm(&self) -> Algorithm;
 
     fn domain_key(&self) -> String {
-        let s = self.s();
-        let d = self.d();
+        let s = self.selector();
+        let d = self.domain();
         let mut key = String::with_capacity(s.len() + d.len() + 13);
         key.push_str(s);
         key.push_str("._domainkey.");
@@ -31,6 +31,6 @@ pub(crate) trait VerifySignature {
     }
 
     fn verify(&self, record: &DomainKey, hh: &[u8]) -> crate::Result<()> {
-        record.p.verify(hh, self.b(), self.a())
+        record.p.verify(hh, self.signature(), self.algorithm())
     }
 }

--- a/src/common/verify.rs
+++ b/src/common/verify.rs
@@ -8,15 +8,7 @@
  * except according to those terms.
  */
 
-use rsa::PaddingScheme;
-use sha1::Sha1;
-use sha2::Sha256;
-
-use crate::{
-    common::crypto::Algorithm,
-    dkim::{DomainKey, PublicKey},
-    Error,
-};
+use crate::{common::crypto::Algorithm, dkim::DomainKey};
 
 pub(crate) trait VerifySignature {
     fn s(&self) -> &str;
@@ -39,34 +31,6 @@ pub(crate) trait VerifySignature {
     }
 
     fn verify(&self, record: &DomainKey, hh: &[u8]) -> crate::Result<()> {
-        match (&self.a(), &record.p) {
-            (Algorithm::RsaSha256, PublicKey::Rsa(public_key)) => rsa::PublicKey::verify(
-                public_key,
-                PaddingScheme::new_pkcs1v15_sign::<Sha256>(),
-                hh,
-                self.b(),
-            )
-            .map_err(|_| Error::FailedVerification),
-
-            (Algorithm::RsaSha1, PublicKey::Rsa(public_key)) => rsa::PublicKey::verify(
-                public_key,
-                PaddingScheme::new_pkcs1v15_sign::<Sha1>(),
-                hh,
-                self.b(),
-            )
-            .map_err(|_| Error::FailedVerification),
-
-            (Algorithm::Ed25519Sha256, PublicKey::Ed25519(public_key)) => public_key
-                .verify_strict(
-                    hh,
-                    &ed25519_dalek::Signature::from_bytes(self.b())
-                        .map_err(|err| Error::CryptoError(err.to_string()))?,
-                )
-                .map_err(|_| Error::FailedVerification),
-
-            (_, PublicKey::Revoked) => Err(Error::RevokedPublicKey),
-
-            (_, _) => Err(Error::IncompatibleAlgorithms),
-        }
+        record.p.verify(hh, self.b(), self.a())
     }
 }

--- a/src/dkim/mod.rs
+++ b/src/dkim/mod.rs
@@ -10,12 +10,10 @@
 
 use std::borrow::Cow;
 
-use rsa::RsaPublicKey;
-
 use crate::{
     arc::Set,
     common::{
-        crypto::{Algorithm, HashAlgorithm},
+        crypto::{Algorithm, HashAlgorithm, VerifyingKey},
         verify::VerifySignature,
     },
     ArcOutput, DkimOutput, DkimResult, Error, Version,
@@ -66,10 +64,8 @@ impl Default for Canonicalization {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DomainKey {
-    pub(crate) v: Version,
-    pub(crate) p: PublicKey,
+    pub(crate) p: Box<dyn VerifyingKey>,
     pub(crate) f: u64,
 }
 
@@ -130,13 +126,6 @@ impl From<Service> for u64 {
     fn from(v: Service) -> Self {
         v as u64
     }
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) enum PublicKey {
-    Rsa(RsaPublicKey),
-    Ed25519(ed25519_dalek::PublicKey),
-    Revoked,
 }
 
 impl From<Algorithm> for HashAlgorithm {

--- a/src/dkim/mod.rs
+++ b/src/dkim/mod.rs
@@ -138,19 +138,19 @@ impl From<Algorithm> for HashAlgorithm {
 }
 
 impl<'x> VerifySignature for Signature<'x> {
-    fn b(&self) -> &[u8] {
+    fn signature(&self) -> &[u8] {
         &self.b
     }
 
-    fn a(&self) -> Algorithm {
+    fn algorithm(&self) -> Algorithm {
         self.a
     }
 
-    fn s(&self) -> &str {
+    fn selector(&self) -> &str {
         &self.s
     }
 
-    fn d(&self) -> &str {
+    fn domain(&self) -> &str {
         &self.d
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,6 @@ pub mod dmarc;
 pub mod report;
 pub mod spf;
 
-#[derive(Debug)]
 pub struct Resolver {
     pub(crate) resolver: TokioAsyncResolver,
     pub(crate) cache_txt: LruCache<String, Txt>,
@@ -287,7 +286,7 @@ pub struct Resolver {
     pub(crate) verify_policy: Policy,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub(crate) enum Txt {
     Spf(Arc<Spf>),
     SpfMacro(Arc<Macro>),


### PR DESCRIPTION
Similar to #3 but for the verification side. Added some renaming of trait methods, since I'll look into some simplification of the verification side next and these method names were pretty confusing to keep straight in my head.