### PR TITLE
Make VerifyingKeys responsible for input hashing

### DIFF
--- a/src/arc/seal.rs
+++ b/src/arc/seal.rs
@@ -99,7 +99,7 @@ impl<'x> ArcSet<'x> {
         let mut header_hasher = Sha256::new();
         if !arc_output.set.is_empty() {
             Canonicalization::Relaxed.canonicalize_headers(
-                arc_output.set.iter().flat_map(|set| {
+                &mut arc_output.set.iter().flat_map(|set| {
                     [
                         (set.results.name, set.results.value),
                         (set.signature.name, set.signature.value),
@@ -194,7 +194,7 @@ impl<'x> Signature<'x> {
 
         let body_len = message.body.len();
         self.ch
-            .canonicalize_headers(headers.into_iter().rev(), header_hasher)?;
+            .canonicalize_headers(&mut headers.into_iter().rev(), header_hasher)?;
         self.cb.canonicalize_body(message.body, body_hasher)?;
 
         // Add any missing headers

--- a/src/arc/seal.rs
+++ b/src/arc/seal.rs
@@ -222,8 +222,9 @@ mod test {
             crypto::{Ed25519Key, RsaKey, SigningKey},
             headers::HeaderWriter,
             parse::TxtRecordParser,
+            verify::DomainKey,
         },
-        dkim::{DomainKey, Signature},
+        dkim::Signature,
         AuthenticatedMessage, AuthenticationResults, DkimResult, Resolver,
     };
 

--- a/src/arc/verify.rs
+++ b/src/arc/verify.rs
@@ -17,9 +17,9 @@ use crate::{
     common::{
         crypto::{Algorithm, HashAlgorithm},
         headers::Header,
-        verify::VerifySignature,
+        verify::{DomainKey, VerifySignature},
     },
-    dkim::{verify::Verifier, Canonicalization, DomainKey},
+    dkim::{verify::Verifier, Canonicalization},
     ArcOutput, AuthenticatedMessage, DkimResult, Error, Resolver,
 };
 
@@ -201,7 +201,8 @@ mod test {
     };
 
     use crate::{
-        common::parse::TxtRecordParser, dkim::DomainKey, AuthenticatedMessage, DkimResult, Resolver,
+        common::{parse::TxtRecordParser, verify::DomainKey},
+        AuthenticatedMessage, DkimResult, Resolver,
     };
 
     #[tokio::test]

--- a/src/common/resolver.rs
+++ b/src/common/resolver.rs
@@ -23,7 +23,7 @@ use trust_dns_resolver::{
 };
 
 use crate::{
-    dkim::{Atps, DomainKey, DomainKeyReport},
+    dkim::{Atps, DomainKeyReport},
     dmarc::Dmarc,
     spf::{Macro, Spf},
     Error, Policy, Resolver, Txt, MX,
@@ -32,6 +32,7 @@ use crate::{
 use super::{
     lru::{DnsCache, LruCache},
     parse::TxtRecordParser,
+    verify::DomainKey,
 };
 
 impl Resolver {

--- a/src/common/verify.rs
+++ b/src/common/verify.rs
@@ -8,7 +8,12 @@
  * except according to those terms.
  */
 
-use crate::{common::crypto::Algorithm, dkim::DomainKey};
+use super::crypto::{Algorithm, VerifyingKey};
+
+pub struct DomainKey {
+    pub(crate) p: Box<dyn VerifyingKey>,
+    pub(crate) f: u64,
+}
 
 pub(crate) trait VerifySignature {
     fn selector(&self) -> &str;

--- a/src/dkim/canonicalize.rs
+++ b/src/dkim/canonicalize.rs
@@ -80,7 +80,7 @@ impl Canonicalization {
 
     pub fn canonicalize_headers<'x>(
         &self,
-        headers: impl Iterator<Item = (&'x [u8], &'x [u8])>,
+        headers: &mut dyn Iterator<Item = (&'x [u8], &'x [u8])>,
         mut hasher: impl io::Write,
     ) -> io::Result<()> {
         match self {
@@ -123,7 +123,7 @@ impl Canonicalization {
 
     pub fn hash_headers<'x, T>(
         &self,
-        headers: impl Iterator<Item = (&'x [u8], &'x [u8])>,
+        headers: &mut dyn Iterator<Item = (&'x [u8], &'x [u8])>,
     ) -> io::Result<Vec<u8>>
     where
         T: Digest + io::Write,
@@ -188,7 +188,7 @@ impl<'x> Signature<'x> {
             .unwrap_or_default();
         let body_len = body.len();
         self.ch
-            .canonicalize_headers(headers.into_iter().rev(), header_hasher)?;
+            .canonicalize_headers(&mut headers.into_iter().rev(), header_hasher)?;
         self.cb.canonicalize_body(body, body_hasher)?;
 
         // Add any missing headers
@@ -272,7 +272,7 @@ mod test {
                 let mut body = Vec::new();
 
                 canonicalization
-                    .canonicalize_headers(parsed_headers.clone().into_iter(), &mut headers)
+                    .canonicalize_headers(&mut parsed_headers.clone().into_iter(), &mut headers)
                     .unwrap();
                 canonicalization
                     .canonicalize_body(raw_body, &mut body)

--- a/src/dkim/mod.rs
+++ b/src/dkim/mod.rs
@@ -13,7 +13,7 @@ use std::borrow::Cow;
 use crate::{
     arc::Set,
     common::{
-        crypto::{Algorithm, HashAlgorithm, VerifyingKey},
+        crypto::{Algorithm, HashAlgorithm},
         verify::VerifySignature,
     },
     ArcOutput, DkimOutput, DkimResult, Error, Version,
@@ -62,11 +62,6 @@ impl Default for Canonicalization {
     fn default() -> Self {
         Canonicalization::Relaxed
     }
-}
-
-pub struct DomainKey {
-    pub(crate) p: Box<dyn VerifyingKey>,
-    pub(crate) f: u64,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/src/dkim/parse.rs
+++ b/src/dkim/parse.rs
@@ -13,14 +13,14 @@ use std::slice::Iter;
 use mail_parser::decoders::base64::base64_decode_stream;
 
 use crate::{
-    common::{crypto::VerifyingKeyType, parse::*},
+    common::{crypto::VerifyingKeyType, parse::*, verify::DomainKey},
     dkim::{RR_EXPIRATION, RR_SIGNATURE, RR_UNKNOWN_TAG, RR_VERIFICATION},
     Error,
 };
 
 use super::{
-    Algorithm, Atps, Canonicalization, DomainKey, DomainKeyReport, Flag, HashAlgorithm, Service,
-    Signature, Version, RR_DNS, RR_OTHER, RR_POLICY,
+    Algorithm, Atps, Canonicalization, DomainKeyReport, Flag, HashAlgorithm, Service, Signature,
+    Version, RR_DNS, RR_OTHER, RR_POLICY,
 };
 
 const ATPSH: u64 = (b'a' as u64)
@@ -463,11 +463,12 @@ mod test {
         common::{
             crypto::{Algorithm, R_HASH_SHA1, R_HASH_SHA256},
             parse::TxtRecordParser,
+            verify::DomainKey,
         },
         dkim::{
-            Canonicalization, DomainKey, DomainKeyReport, Signature, RR_DNS, RR_EXPIRATION,
-            RR_OTHER, RR_POLICY, RR_SIGNATURE, RR_UNKNOWN_TAG, RR_VERIFICATION,
-            R_FLAG_MATCH_DOMAIN, R_FLAG_TESTING, R_SVC_ALL, R_SVC_EMAIL,
+            Canonicalization, DomainKeyReport, Signature, RR_DNS, RR_EXPIRATION, RR_OTHER,
+            RR_POLICY, RR_SIGNATURE, RR_UNKNOWN_TAG, RR_VERIFICATION, R_FLAG_MATCH_DOMAIN,
+            R_FLAG_TESTING, R_SVC_ALL, R_SVC_EMAIL,
         },
     };
 

--- a/src/dkim/sign.rs
+++ b/src/dkim/sign.rs
@@ -158,8 +158,9 @@ mod test {
         common::{
             crypto::{Ed25519Key, RsaKey},
             parse::TxtRecordParser,
+            verify::DomainKey,
         },
-        dkim::{Atps, Canonicalization, DomainKey, DomainKeyReport, HashAlgorithm, Signature},
+        dkim::{Atps, Canonicalization, DomainKeyReport, HashAlgorithm, Signature},
         AuthenticatedMessage, DkimOutput, DkimResult, Resolver,
     };
 

--- a/src/dkim/verify.rs
+++ b/src/dkim/verify.rs
@@ -14,13 +14,16 @@ use sha1::{Digest, Sha1};
 use sha2::Sha256;
 
 use crate::{
-    common::{base32::Base32Writer, verify::VerifySignature},
+    common::{
+        base32::Base32Writer,
+        verify::{DomainKey, VerifySignature},
+    },
     is_within_pct, AuthenticatedMessage, DkimOutput, DkimResult, Error, Resolver,
 };
 
 use super::{
-    Algorithm, Atps, DomainKey, DomainKeyReport, Flag, HashAlgorithm, Signature, RR_DNS,
-    RR_EXPIRATION, RR_OTHER, RR_SIGNATURE, RR_VERIFICATION,
+    Algorithm, Atps, DomainKeyReport, Flag, HashAlgorithm, Signature, RR_DNS, RR_EXPIRATION,
+    RR_OTHER, RR_SIGNATURE, RR_VERIFICATION,
 };
 
 impl Resolver {
@@ -375,8 +378,8 @@ mod test {
     };
 
     use crate::{
-        common::parse::TxtRecordParser,
-        dkim::{verify::Verifier, DomainKey},
+        common::{parse::TxtRecordParser, verify::DomainKey},
+        dkim::verify::Verifier,
         AuthenticatedMessage, DkimResult, Resolver,
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,8 +262,8 @@ use std::{
 };
 
 use arc::Set;
-use common::{crypto::HashAlgorithm, headers::Header, lru::LruCache};
-use dkim::{Atps, Canonicalization, DomainKey, DomainKeyReport};
+use common::{crypto::HashAlgorithm, headers::Header, lru::LruCache, verify::DomainKey};
+use dkim::{Atps, Canonicalization, DomainKeyReport};
 use dmarc::Dmarc;
 use spf::{Macro, Spf};
 use trust_dns_resolver::{proto::op::ResponseCode, TokioAsyncResolver};


### PR DESCRIPTION
This is working in the direction of #1 some more by avoiding `Signature` and `Seal` having to know about specific hash algorithm implementations.

Adds a little more dynamic dispatch for the header iterators, but I still think the cost is probably negligible in the context of they get used (once per header, with many hashing calls per header).