### PR TITLE
Replace usage of io::Write with custom Writer trait

### DIFF
--- a/src/common/auth_results.rs
+++ b/src/common/auth_results.rs
@@ -8,7 +8,7 @@
  * except according to those terms.
  */
 
-use std::{borrow::Cow, fmt::Write, io, net::IpAddr};
+use std::{borrow::Cow, fmt::Write, net::IpAddr};
 
 use mail_builder::encoders::base64::base64_encode;
 
@@ -17,7 +17,7 @@ use crate::{
     ReceivedSpf, SpfOutput, SpfResult,
 };
 
-use super::headers::HeaderWriter;
+use super::headers::{HeaderWriter, Writer};
 
 impl<'x> AuthenticationResults<'x> {
     pub fn new(hostname: &'x str) -> Self {
@@ -118,23 +118,23 @@ impl<'x> AuthenticationResults<'x> {
 }
 
 impl<'x> HeaderWriter for AuthenticationResults<'x> {
-    fn write_header(&self, mut writer: impl io::Write) -> io::Result<()> {
-        writer.write_all(b"Authentication-Results: ")?;
-        writer.write_all(self.hostname.as_bytes())?;
+    fn write_header(&self, writer: &mut impl Writer) {
+        writer.write(b"Authentication-Results: ");
+        writer.write(self.hostname.as_bytes());
         if !self.auth_results.is_empty() {
-            writer.write_all(self.auth_results.as_bytes())?;
+            writer.write(self.auth_results.as_bytes());
         } else {
-            writer.write_all(b"; none")?;
+            writer.write(b"; none");
         }
-        writer.write_all(b"\r\n")
+        writer.write(b"\r\n");
     }
 }
 
 impl HeaderWriter for ReceivedSpf {
-    fn write_header(&self, mut writer: impl io::Write) -> io::Result<()> {
-        writer.write_all(b"Received-SPF: ")?;
-        writer.write_all(self.received_spf.as_bytes())?;
-        writer.write_all(b"\r\n")
+    fn write_header(&self, writer: &mut impl Writer) {
+        writer.write(b"Received-SPF: ");
+        writer.write(self.received_spf.as_bytes());
+        writer.write(b"\r\n");
     }
 }
 

--- a/src/common/crypto.rs
+++ b/src/common/crypto.rs
@@ -165,7 +165,7 @@ impl VerifyingKey for RsaPublicKey {
                 self.inner
                     .verify(
                         PaddingScheme::new_pkcs1v15_sign::<Sha256>(),
-                        &hash,
+                        hash.as_ref(),
                         signature,
                     )
                     .map_err(|_| Error::FailedVerification)
@@ -173,7 +173,11 @@ impl VerifyingKey for RsaPublicKey {
             Algorithm::RsaSha1 => {
                 let hash = canonicalization.hash_headers::<Sha1>(headers);
                 self.inner
-                    .verify(PaddingScheme::new_pkcs1v15_sign::<Sha1>(), &hash, signature)
+                    .verify(
+                        PaddingScheme::new_pkcs1v15_sign::<Sha1>(),
+                        hash.as_ref(),
+                        signature,
+                    )
                     .map_err(|_| Error::FailedVerification)
             }
             Algorithm::Ed25519Sha256 => Err(Error::IncompatibleAlgorithms),
@@ -200,7 +204,7 @@ impl VerifyingKey for Ed25519PublicKey {
         let hash = canonicalization.hash_headers::<Sha256>(headers);
         self.inner
             .verify_strict(
-                &hash,
+                hash.as_ref(),
                 &ed25519_dalek::Signature::from_bytes(signature)
                     .map_err(|err| Error::CryptoError(err.to_string()))?,
             )

--- a/src/common/headers.rs
+++ b/src/common/headers.rs
@@ -9,7 +9,6 @@
  */
 
 use std::{
-    io,
     iter::{Enumerate, Peekable},
     slice::Iter,
 };
@@ -266,11 +265,26 @@ impl<'x> Iterator for HeaderParser<'x> {
 }
 
 pub trait HeaderWriter: Sized {
-    fn write_header(&self, writer: impl io::Write) -> io::Result<()>;
+    fn write_header(&self, writer: &mut impl Writer);
     fn to_header(&self) -> String {
         let mut buf = Vec::new();
-        self.write_header(&mut buf).unwrap();
+        self.write_header(&mut buf);
         String::from_utf8(buf).unwrap()
+    }
+}
+
+pub trait Writer {
+    fn write(&mut self, buf: &[u8]);
+
+    fn write_len(&mut self, buf: &[u8], len: &mut usize) {
+        self.write(buf);
+        *len += buf.len();
+    }
+}
+
+impl Writer for Vec<u8> {
+    fn write(&mut self, buf: &[u8]) {
+        self.extend(buf);
     }
 }
 

--- a/src/common/message.rs
+++ b/src/common/message.rs
@@ -149,8 +149,7 @@ impl<'x> AuthenticatedMessage<'x> {
             *bh = match ha {
                 HashAlgorithm::Sha256 => cb.hash_body::<Sha256>(message.body, *l),
                 HashAlgorithm::Sha1 => cb.hash_body::<Sha1>(message.body, *l),
-            }
-            .unwrap_or_default();
+            };
         }
 
         // Sort ARC headers

--- a/src/common/message.rs
+++ b/src/common/message.rs
@@ -147,8 +147,8 @@ impl<'x> AuthenticatedMessage<'x> {
         // Calculate body hashes
         for (cb, ha, l, bh) in &mut message.body_hashes {
             *bh = match ha {
-                HashAlgorithm::Sha256 => cb.hash_body::<Sha256>(message.body, *l),
-                HashAlgorithm::Sha1 => cb.hash_body::<Sha1>(message.body, *l),
+                HashAlgorithm::Sha256 => cb.hash_body::<Sha256>(message.body, *l).as_ref().to_vec(),
+                HashAlgorithm::Sha1 => cb.hash_body::<Sha1>(message.body, *l).as_ref().to_vec(),
             };
         }
 

--- a/src/dkim/canonicalize.rs
+++ b/src/dkim/canonicalize.rs
@@ -119,13 +119,13 @@ impl Canonicalization {
     pub fn hash_headers<'x, T: Digest + Writer>(
         &self,
         headers: &mut dyn Iterator<Item = (&'x [u8], &'x [u8])>,
-    ) -> Vec<u8> {
+    ) -> impl AsRef<[u8]> {
         let mut hasher = T::new();
         self.canonicalize_headers(headers, &mut hasher);
-        hasher.finalize().to_vec()
+        hasher.finalize()
     }
 
-    pub fn hash_body<T: Digest + Writer>(&self, body: &[u8], l: u64) -> Vec<u8> {
+    pub fn hash_body<T: Digest + Writer>(&self, body: &[u8], l: u64) -> impl AsRef<[u8]> {
         let mut hasher = T::new();
         self.canonicalize_body(
             if l == 0 || body.is_empty() {
@@ -135,7 +135,7 @@ impl Canonicalization {
             },
             &mut hasher,
         );
-        hasher.finalize().to_vec()
+        hasher.finalize()
     }
 
     pub fn serialize_name(&self, writer: &mut impl Writer) {

--- a/src/dkim/canonicalize.rs
+++ b/src/dkim/canonicalize.rs
@@ -8,19 +8,16 @@
  * except according to those terms.
  */
 
-use std::{
-    borrow::Cow,
-    io::{self},
-};
+use std::borrow::Cow;
 
 use sha1::Digest;
 
-use crate::common::headers::HeaderIterator;
+use crate::common::headers::{HeaderIterator, Writer};
 
 use super::{Canonicalization, Signature};
 
 impl Canonicalization {
-    pub fn canonicalize_body(&self, body: &[u8], mut hasher: impl io::Write) -> io::Result<()> {
+    pub fn canonicalize_body(&self, body: &[u8], hasher: &mut impl Writer) {
         let mut crlf_seq = 0;
 
         match self {
@@ -31,7 +28,7 @@ impl Canonicalization {
                     match ch {
                         b' ' | b'\t' => {
                             while crlf_seq > 0 {
-                                let _ = hasher.write(b"\r\n")?;
+                                hasher.write(b"\r\n");
                                 crlf_seq -= 1;
                             }
                         }
@@ -41,15 +38,15 @@ impl Canonicalization {
                         b'\r' => {}
                         _ => {
                             while crlf_seq > 0 {
-                                let _ = hasher.write(b"\r\n")?;
+                                hasher.write(b"\r\n");
                                 crlf_seq -= 1;
                             }
 
                             if last_ch == b' ' || last_ch == b'\t' {
-                                let _ = hasher.write(b" ")?;
+                                hasher.write(b" ");
                             }
 
-                            let _ = hasher.write(&[ch])?;
+                            hasher.write(&[ch]);
                         }
                     }
 
@@ -65,78 +62,70 @@ impl Canonicalization {
                         b'\r' => {}
                         _ => {
                             while crlf_seq > 0 {
-                                let _ = hasher.write(b"\r\n")?;
+                                hasher.write(b"\r\n");
                                 crlf_seq -= 1;
                             }
-                            let _ = hasher.write(&[ch])?;
+                            hasher.write(&[ch]);
                         }
                     }
                 }
             }
         }
 
-        hasher.write_all(b"\r\n")
+        hasher.write(b"\r\n");
     }
 
     pub fn canonicalize_headers<'x>(
         &self,
         headers: &mut dyn Iterator<Item = (&'x [u8], &'x [u8])>,
-        mut hasher: impl io::Write,
-    ) -> io::Result<()> {
+        hasher: &mut impl Writer,
+    ) {
         match self {
             Canonicalization::Relaxed => {
                 for (name, value) in headers {
                     for &ch in name {
                         if !ch.is_ascii_whitespace() {
-                            let _ = hasher.write(&[ch.to_ascii_lowercase()])?;
+                            hasher.write(&[ch.to_ascii_lowercase()]);
                         }
                     }
-                    let _ = hasher.write(b":")?;
-                    let mut bytes_written = 0;
+                    hasher.write(b":");
+                    let mut bw = 0;
                     let mut last_ch = 0;
 
                     for &ch in value {
                         if !ch.is_ascii_whitespace() {
-                            if [b' ', b'\t'].contains(&last_ch) && bytes_written > 0 {
-                                bytes_written += hasher.write(b" ")?;
+                            if [b' ', b'\t'].contains(&last_ch) && bw > 0 {
+                                hasher.write_len(b" ", &mut bw);
                             }
-                            bytes_written += hasher.write(&[ch])?;
+                            hasher.write_len(&[ch], &mut bw);
                         }
                         last_ch = ch;
                     }
                     if last_ch == b'\n' {
-                        let _ = hasher.write(b"\r\n");
+                        hasher.write(b"\r\n");
                     }
                 }
             }
             Canonicalization::Simple => {
                 for (name, value) in headers {
-                    let _ = hasher.write(name)?;
-                    let _ = hasher.write(b":")?;
-                    let _ = hasher.write(value)?;
+                    hasher.write(name);
+                    hasher.write(b":");
+                    hasher.write(value);
                 }
             }
         }
-
-        Ok(())
     }
 
-    pub fn hash_headers<'x, T>(
+    pub fn hash_headers<'x, T: Digest + Writer>(
         &self,
         headers: &mut dyn Iterator<Item = (&'x [u8], &'x [u8])>,
-    ) -> io::Result<Vec<u8>>
-    where
-        T: Digest + io::Write,
-    {
+    ) -> Vec<u8> {
         let mut hasher = T::new();
-        self.canonicalize_headers(headers, &mut hasher)?;
-        Ok(hasher.finalize().to_vec())
+        self.canonicalize_headers(headers, &mut hasher);
+        hasher.finalize().to_vec()
     }
 
-    pub fn hash_body<T>(&self, body: &[u8], l: u64) -> io::Result<Vec<u8>>
-    where
-        T: Digest + io::Write,
-    {
+    pub fn hash_body<T: Digest + Writer>(&self, body: &[u8], l: u64) -> Vec<u8> {
         let mut hasher = T::new();
         self.canonicalize_body(
             if l == 0 || body.is_empty() {
@@ -145,15 +134,15 @@ impl Canonicalization {
                 &body[..std::cmp::min(l as usize, body.len())]
             },
             &mut hasher,
-        )?;
-        Ok(hasher.finalize().to_vec())
+        );
+        hasher.finalize().to_vec()
     }
 
-    pub fn serialize_name(&self, mut writer: impl io::Write) -> io::Result<()> {
-        writer.write_all(match self {
+    pub fn serialize_name(&self, writer: &mut impl Writer) {
+        writer.write(match self {
             Canonicalization::Relaxed => b"relaxed",
             Canonicalization::Simple => b"simple",
-        })
+        });
     }
 }
 
@@ -162,9 +151,9 @@ impl<'x> Signature<'x> {
     pub(crate) fn canonicalize(
         &self,
         message: &'x [u8],
-        header_hasher: impl io::Write,
-        body_hasher: impl io::Write,
-    ) -> crate::Result<(usize, Vec<Cow<'x, str>>)> {
+        header_hasher: &mut impl Writer,
+        body_hasher: &mut impl Writer,
+    ) -> (usize, Vec<Cow<'x, str>>) {
         let mut headers_it = HeaderIterator::new(message);
         let mut headers = Vec::with_capacity(self.h.len());
         let mut found_headers = vec![false; self.h.len()];
@@ -188,8 +177,8 @@ impl<'x> Signature<'x> {
             .unwrap_or_default();
         let body_len = body.len();
         self.ch
-            .canonicalize_headers(&mut headers.into_iter().rev(), header_hasher)?;
-        self.cb.canonicalize_body(body, body_hasher)?;
+            .canonicalize_headers(&mut headers.into_iter().rev(), header_hasher);
+        self.cb.canonicalize_body(body, body_hasher);
 
         // Add any missing headers
         signed_headers.reverse();
@@ -199,7 +188,7 @@ impl<'x> Signature<'x> {
             }
         }
 
-        Ok((body_len, signed_headers))
+        (body_len, signed_headers)
     }
 }
 
@@ -272,11 +261,8 @@ mod test {
                 let mut body = Vec::new();
 
                 canonicalization
-                    .canonicalize_headers(&mut parsed_headers.clone().into_iter(), &mut headers)
-                    .unwrap();
-                canonicalization
-                    .canonicalize_body(raw_body, &mut body)
-                    .unwrap();
+                    .canonicalize_headers(&mut parsed_headers.clone().into_iter(), &mut headers);
+                canonicalization.canonicalize_body(raw_body, &mut body);
 
                 assert_eq!(expected_headers, String::from_utf8(headers).unwrap());
                 assert_eq!(expected_body, String::from_utf8(body).unwrap());

--- a/src/dkim/sign.rs
+++ b/src/dkim/sign.rs
@@ -52,7 +52,7 @@ impl<'x> Signature<'x> {
 
         // Canonicalize headers and body
         let (body_len, signed_headers) =
-            self.canonicalize(message, &mut header_hasher, &mut body_hasher)?;
+            self.canonicalize(message, &mut header_hasher, &mut body_hasher);
 
         if signed_headers.is_empty() {
             return Err(Error::NoHeadersFound);
@@ -68,7 +68,7 @@ impl<'x> Signature<'x> {
         }
 
         // Add signature to hash
-        self.write(&mut header_hasher, false)?;
+        self.write(&mut header_hasher, false);
 
         // Sign
         let b = with_key.sign(&header_hasher.finalize())?;
@@ -442,7 +442,7 @@ GMot/L2x0IYyMLAz6oLWh2hm7zwtb0CgOrPo1ke44hFYnfc=
         expect: Result<(), super::Error>,
     ) -> Vec<DkimOutput<'x>> {
         let mut message = Vec::with_capacity(message_.len() + 100);
-        signature.write(&mut message, true).unwrap();
+        signature.write(&mut message, true);
         message.extend_from_slice(message_.as_bytes());
 
         let message = AuthenticatedMessage::parse(&message).unwrap();


### PR DESCRIPTION
In looking at how hashing was implemented, I noticed that the use of the std `io::Write` trait introduced quite a bit of fallibility that didn't seem necessary for most uses at least within the crate (in particular, the`Digest` trait's `update()` method that is being called by the `io::Write` wrapper don't fail -- neither does `Vec::extend()`). The fallibility then requires odd workarounds such as the `unwrap_or_default()` calls on hash output. In this case it seemed better to me to introduce a custom `Writer` trait with an infallible `write()` method. Since most calls don't need the length of the written slice, I added a default method implementation wrapper that does the length tracking which is used where needed.

I'm still not fully clear on which parts of this are public API; if you have a need for callers that want to write into actually fallible `io::Write` implementations directly I suppose this doesn't fly, but I feel like there will probably always be a layer of buffering in between.