### PR TITLE
Update ed25519-dalek to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ test = []
 
 [dependencies]
 ahash = "0.8.0"
-ed25519-dalek = { version = "1.0", optional = true }
+ed25519-dalek = { version = "2.0", optional = true }
 flate2 = "1.0.25"
 lru-cache = "0.1.2"
 mail-parser = { version = "0.9", git = "https://github.com/stalwartlabs/mail-parser", features = ["ludicrous_mode", "full_encoding"] }

--- a/examples/dkim_sign.rs
+++ b/examples/dkim_sign.rs
@@ -64,11 +64,8 @@ fn main() {
 
     // Sign an e-mail message using ED25519-SHA256
     #[cfg(feature = "rust-crypto")]
-    let pk_ed = Ed25519Key::from_bytes(
-        &base64_decode(ED25519_PUBLIC_KEY.as_bytes()).unwrap(),
-        &base64_decode(ED25519_PRIVATE_KEY.as_bytes()).unwrap(),
-    )
-    .unwrap();
+    let pk_ed =
+        Ed25519Key::from_bytes(&base64_decode(ED25519_PRIVATE_KEY.as_bytes()).unwrap()).unwrap();
     #[cfg(all(feature = "ring", not(feature = "rust-crypto")))]
     let pk_ed = Ed25519Key::from_seed_and_public_key(
         &base64_decode(ED25519_PRIVATE_KEY.as_bytes()).unwrap(),

--- a/src/arc/seal.rs
+++ b/src/arc/seal.rs
@@ -293,7 +293,7 @@ mod test {
                 "scamorza.org",
                 "ed",
                 #[cfg(feature = "rust-crypto")]
-                Ed25519Key::from_bytes(&pk_ed_public, &pk_ed_private).unwrap(),
+                Ed25519Key::from_bytes(&pk_ed_private).unwrap(),
                 #[cfg(all(feature = "ring", not(feature = "rust-crypto")))]
                 Ed25519Key::from_seed_and_public_key(&pk_ed_private, &pk_ed_public).unwrap(),
             )

--- a/src/dkim/sign.rs
+++ b/src/dkim/sign.rs
@@ -215,11 +215,8 @@ mod test {
 
         // Create private keys
         #[cfg(feature = "rust-crypto")]
-        let pk_ed = Ed25519Key::from_bytes(
-            &base64_decode(ED25519_PUBLIC_KEY.rsplit_once("p=").unwrap().1.as_bytes()).unwrap(),
-            &base64_decode(ED25519_PRIVATE_KEY.as_bytes()).unwrap(),
-        )
-        .unwrap();
+        let pk_ed = Ed25519Key::from_bytes(&base64_decode(ED25519_PRIVATE_KEY.as_bytes()).unwrap())
+            .unwrap();
         #[cfg(all(feature = "ring", not(feature = "rust-crypto")))]
         let pk_ed = Ed25519Key::from_seed_and_public_key(
             &base64_decode(ED25519_PRIVATE_KEY.as_bytes()).unwrap(),


### PR DESCRIPTION
Hi :) This fixes https://github.com/advisories/GHSA-w5vr-6qhr-36cc / https://rustsec.org/advisories/RUSTSEC-2022-0093.html being pulled in when using the `rust-crypto` feature.

I am using this downstream in my own mailserver (by the way thanks for the crate!) and noticed that I cant update this crate on my side and it seems to be that mail-auth is the one blocking the update :)