### PR TITLE
Make DMARC record pct publicly accessible

### DIFF
--- a/src/dmarc/mod.rs
+++ b/src/dmarc/mod.rs
@@ -204,6 +204,10 @@ impl DmarcOutput {
 }
 
 impl Dmarc {
+    pub fn pct(&self) -> u8 {
+        self.pct
+    }
+
     pub fn ruf(&self) -> &[URI] {
         &self.ruf
     }


### PR DESCRIPTION
This change allows users of the library to make a decision on enforcement of a sender's policy based on the percentage indicated by their DMARC record.