### PR TITLE
Check PTR against FQDN (including dot at the end)

### DIFF
--- a/resources/spf/basic.yml
+++ b/resources/spf/basic.yml
@@ -95,8 +95,8 @@ records:
   spf: mx.test.org v=spf1 mx -all
   spf: ptr.test.org v=spf1 ptr:test.org -all
   mx: mx.test.org 10.0.0.1,10.0.0.2,10.0.0.3,10.0.0.4,10.0.0.5,10.0.0.6,10.0.0.7,10.0.0.8,10.0.0.9,10.0.0.10,10.0.0.11
-  ptr: 10.0.0.1 h1.test.org
-  ptr: 10.0.0.11 h1.test.org, h2.test.org, h3.test.org, h4.test.org, h5.test.org, h6.test.org, h7.test.org, h8.test.org, h9.test.org, h10.test.org, h11.test.org
+  ptr: 10.0.0.1 h1.test.org.
+  ptr: 10.0.0.11 h1.test.org., h2.test.org., h3.test.org., h4.test.org., h5.test.org., h6.test.org., h7.test.org., h8.test.org., h9.test.org., h10.test.org., h11.test.org.
   a: h1.test.org 10.0.0.1
   a: h11.test.org 10.0.0.11
 tests:

--- a/resources/spf/examples.yml
+++ b/resources/spf/examples.yml
@@ -10,14 +10,14 @@ records:
   a: example.com 192.0.2.10, 192.0.2.11
   a: mail-c.example.org 192.0.2.140
   mx: example.org 192.0.2.140
-  ptr: 192.0.2.10 example.com
-  ptr: 192.0.2.11 example.com
-  ptr: 192.0.2.65 amy.example.com
-  ptr: 192.0.2.66 bob.example.com
-  ptr: 192.0.2.129 mail-a.example.com
-  ptr: 192.0.2.130 mail-b.example.com
-  ptr: 192.0.2.140 mail-c.example.org
-  ptr: 10.0.0.4 bob.example.com
+  ptr: 192.0.2.10 example.com.
+  ptr: 192.0.2.11 example.com.
+  ptr: 192.0.2.65 amy.example.com.
+  ptr: 192.0.2.66 bob.example.com.
+  ptr: 192.0.2.129 mail-a.example.com.
+  ptr: 192.0.2.130 mail-b.example.com.
+  ptr: 192.0.2.140 mail-c.example.org.
+  ptr: 10.0.0.4 bob.example.com.
 tests:
   - sender: user@example.com
     domain: example.com

--- a/resources/spf/ptr.yml
+++ b/resources/spf/ptr.yml
@@ -3,9 +3,9 @@
 
 name: PTR subdomain match
 records:
-  ptr: 192.168.1.5 pass.test.org
-  ptr: 192.168.1.6 incomplete.test.org
-  ptr: 10.0.0.1 other.domain.org
+  ptr: 192.168.1.5 pass.test.org.
+  ptr: 192.168.1.6 incomplete.test.org.
+  ptr: 10.0.0.1 other.domain.org.
   a: pass.test.org 192.168.1.5
   a: other.domain.org 10.0.0.1
   spf: test.org v=spf1 ptr -all

--- a/src/spf/verify.rs
+++ b/src/spf/verify.rs
@@ -259,7 +259,7 @@ impl Resolver {
                         }
 
                         let target_addr = macro_string.eval(&vars, &domain, true).to_lowercase();
-                        let target_sub_addr = format!(".{target_addr}");
+                        let target_sub_addr = format!(".{target_addr}.");
                         let mut matches = false;
 
                         if let Ok(records) = self.ptr_lookup(ip).await {


### PR DESCRIPTION
PTR records are returned with a dot at the end (as FQDN) by hickory_resolver.
Without this fix, SPF checks for some mail providers (for example Yahoo and OVH) will fail without indicating errors.

Example program, showing the issue for Yahoo (easy testing due to free / open registration)

```
use mail_auth::Resolver;

// This is the main function.
#[tokio::main]
async fn main() {
    let resolver = Resolver::new_google().unwrap();

    let result = resolver
        .verify_spf_sender("87.248.110.31".parse().unwrap(), "sonic307-54.consmr.mail.ir2.yahoo.com", "my-local-domain.org", "testmail@yahoo.com")
        .await;
    println!("{}", result.result());

}
```

Expected result: Pass
Actual Result without this fix: Neutral (due to failure checking PTR records)

Thanks for your efforts!
