### PR TITLE
Allow external usage of parsing functions for SPF, DMARC and DKIM structs

### DIFF
--- a/src/common/verify.rs
+++ b/src/common/verify.rs
@@ -15,8 +15,8 @@ use crate::{dkim::Canonicalization, Error, IprevOutput, IprevResult, Resolver};
 use super::crypto::{Algorithm, VerifyingKey};
 
 pub struct DomainKey {
-    pub(crate) p: Box<dyn VerifyingKey + Send + Sync>,
-    pub(crate) f: u64,
+    pub p: Box<dyn VerifyingKey + Send + Sync>,
+    pub f: u64,
 }
 
 impl Resolver {

--- a/src/dkim/mod.rs
+++ b/src/dkim/mod.rs
@@ -47,23 +47,23 @@ pub struct Done;
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct Signature {
-    pub(crate) v: u32,
-    pub(crate) a: Algorithm,
-    pub(crate) d: String,
-    pub(crate) s: String,
-    pub(crate) b: Vec<u8>,
-    pub(crate) bh: Vec<u8>,
-    pub(crate) h: Vec<String>,
-    pub(crate) z: Vec<String>,
-    pub(crate) i: String,
-    pub(crate) l: u64,
-    pub(crate) x: u64,
-    pub(crate) t: u64,
-    pub(crate) r: bool,                      // RFC 6651
-    pub(crate) atps: Option<String>,         // RFC 6541
-    pub(crate) atpsh: Option<HashAlgorithm>, // RFC 6541
-    pub(crate) ch: Canonicalization,
-    pub(crate) cb: Canonicalization,
+    pub v: u32,
+    pub a: Algorithm,
+    pub d: String,
+    pub s: String,
+    pub b: Vec<u8>,
+    pub bh: Vec<u8>,
+    pub h: Vec<String>,
+    pub z: Vec<String>,
+    pub i: String,
+    pub l: u64,
+    pub x: u64,
+    pub t: u64,
+    pub r: bool,                      // RFC 6651
+    pub atps: Option<String>,         // RFC 6541
+    pub atpsh: Option<HashAlgorithm>, // RFC 6541
+    pub ch: Canonicalization,
+    pub cb: Canonicalization,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/src/dmarc/mod.rs
+++ b/src/dmarc/mod.rs
@@ -19,20 +19,20 @@ pub mod verify;
 
 #[derive(Debug, Hash, Clone, PartialEq, Eq)]
 pub struct Dmarc {
-    pub(crate) v: Version,
-    pub(crate) adkim: Alignment,
-    pub(crate) aspf: Alignment,
-    pub(crate) fo: Report,
-    pub(crate) np: Policy,
-    pub(crate) p: Policy,
-    pub(crate) psd: Psd,
-    pub(crate) pct: u8,
-    pub(crate) rf: u8,
-    pub(crate) ri: u32,
-    pub(crate) rua: Vec<URI>,
-    pub(crate) ruf: Vec<URI>,
-    pub(crate) sp: Policy,
-    pub(crate) t: bool,
+    pub v: Version,
+    pub adkim: Alignment,
+    pub aspf: Alignment,
+    pub fo: Report,
+    pub np: Policy,
+    pub p: Policy,
+    pub psd: Psd,
+    pub pct: u8,
+    pub rf: u8,
+    pub ri: u32,
+    pub rua: Vec<URI>,
+    pub ruf: Vec<URI>,
+    pub sp: Policy,
+    pub t: bool,
 }
 
 #[derive(Debug, Hash, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -43,13 +43,13 @@ pub struct URI {
 }
 
 #[derive(Debug, Hash, Clone, PartialEq, Eq)]
-pub(crate) enum Alignment {
+pub enum Alignment {
     Relaxed,
     Strict,
 }
 
 #[derive(Debug, Hash, Clone, PartialEq, Eq)]
-pub(crate) enum Psd {
+pub enum Psd {
     Yes,
     No,
     Default,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,7 +439,7 @@ pub enum IprevResult {
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
-pub(crate) enum Version {
+pub enum Version {
     V1,
 }
 

--- a/src/spf/mod.rs
+++ b/src/spf/mod.rs
@@ -27,7 +27,7 @@ use crate::{is_within_pct, SpfOutput, SpfResult, Version};
 */
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) enum Qualifier {
+pub enum Qualifier {
     Pass,
     Fail,
     SoftFail,
@@ -39,7 +39,7 @@ pub(crate) enum Qualifier {
                       / a / mx / ptr / ip4 / ip6 / exists )
 */
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) enum Mechanism {
+pub enum Mechanism {
     All,
     Include {
         macro_string: Macro,
@@ -74,9 +74,9 @@ pub(crate) enum Mechanism {
     directive        = [ qualifier ] mechanism
 */
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) struct Directive {
-    pub(crate) qualifier: Qualifier,
-    pub(crate) mechanism: Mechanism,
+pub struct Directive {
+    pub qualifier: Qualifier,
+    pub mechanism: Mechanism,
 }
 
 /*
@@ -132,13 +132,13 @@ pub enum Macro {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Spf {
-    version: Version,
-    directives: Vec<Directive>,
-    exp: Option<Macro>,
-    redirect: Option<Macro>,
-    ra: Option<Vec<u8>>,
-    rp: u8,
-    rr: u8,
+    pub version: Version,
+    pub directives: Vec<Directive>,
+    pub exp: Option<Macro>,
+    pub redirect: Option<Macro>,
+    pub ra: Option<Vec<u8>>,
+    pub rp: u8,
+    pub rr: u8,
 }
 
 pub(crate) const RR_TEMP_PERM_ERROR: u8 = 0x01;


### PR DESCRIPTION
This is useful for other projects that want to use the parsing functionality on its own, without parsing an entire e-mail. 

Closes #29

Some test code: 

```rust
use mail_auth::{common::parse::TxtRecordParser, spf::Spf, dmarc::Dmarc, dkim::Signature};

fn main() {
    let spf_record = "v=spf1 A:example.com MX -all";
    match Spf::parse(spf_record.as_bytes()) {
        Ok(parsed_record) => {
            println!("SPF: {:?}", parsed_record);
        }, 
        Err(_) => { println!("Whoops"); }
    }

    let dmarc_record = "v=DMARC1; p=quarantine; adkim=s; aspf=s; rua=mailto:report@example.com; pct=100; fo=0:1:d:s;";

    match Dmarc::parse(dmarc_record.as_bytes()) {
        Ok(parsed_record) => {
            println!("Dmarc: {:?}", parsed_record);
        }, 
        Err(_) => { println!("Whoops"); },
    }

    let dkim_signature = "DKIM-Signature: v=1; a=rsa-sha256; s=jun2005.eng; c=relaxed/relaxed; d=example.com; s=dkim; t=1526555738; bh=mhU6OJb5ldZf+z/pX9+0Nc4tj/lmyYHWbR8LgI2Q=; h=To:From:Subject:Date:Message-ID:MIME-Version:Content-Type:Content-Transfer-Encoding; b=s1sdZCzdX9vxocsMSlT7cOrYixl1g8wfkdzrVe7BGN6ZdPV9xu2A";
    match Signature::parse(dkim_signature.as_bytes()) {
        Ok(parsed_record) => {
            println!("Dkim: {:?}", parsed_record);
        }, 
        Err(_) => { println!("Whoops"); },
    }
}
```
