### PR TITLE
Feature gate report module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,10 @@ resolver = "2"
 doctest = false
 
 [features]
-default = ["ring", "rustls-pemfile"]
+default = ["ring", "rustls-pemfile", "report"]
 rust-crypto = ["ed25519-dalek", "rsa", "sha1", "sha2"]
 generate = ["rsa", "rand"]
+report = ["quick-xml"]
 test = []
 
 [dependencies]
@@ -29,7 +30,7 @@ lru-cache = "0.1.2"
 mail-parser = { version = "0.9", features = ["ludicrous_mode", "full_encoding"] }
 mail-builder = { version = "0.3", features = ["ludicrous_mode"] }
 parking_lot = "0.12.0"
-quick-xml = "0.36"
+quick-xml = { version = "0.36", optional = true }
 ring = { version = "0.17", optional = true }
 rsa = { version = "0.9.6", optional = true }
 rustls-pemfile = { version = "2", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub mod common;
 pub mod dkim;
 pub mod dmarc;
 pub mod mta_sts;
+#[cfg(feature = "report")]
 pub mod report;
 pub mod spf;
 


### PR DESCRIPTION
Hi, thanks for your work on this library. 

This puts the `report` module behind a feature gate.  One practical reason for doing this is that the quick-xml package explicitly disables non-utf8 support without enabling the encoding feature. Other packages that depend on quick-xml like RSS libraries often need support for non-utf8 encoding and this creates a compile time error.

Thanks again,

Kevin