### PR TITLE
Make zip dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 default = ["ring", "rustls-pemfile", "report"]
 rust-crypto = ["ed25519-dalek", "rsa", "sha1", "sha2"]
 generate = ["rsa", "rand"]
-report = ["quick-xml"]
+report = ["quick-xml", "zip"]
 test = []
 
 [dependencies]
@@ -37,7 +37,7 @@ serde_json = "1.0"
 sha1 = { version = "0.10", features = ["oid"], optional = true }
 sha2 = { version = "0.10.6", features = ["oid"], optional = true }
 hickory-resolver = { version = "0.24", features = ["dns-over-rustls", "dnssec-ring"] }
-zip = "2.1.1"
+zip = { version = "2.1.1", optional = true }
 rand = { version = "0.8.5", optional = true }
 quick_cache = "0.6.9"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub mod spf;
 
 pub use flate2;
 pub use hickory_resolver;
+#[cfg(feature = "report")]
 pub use zip;
 
 #[derive(Clone)]


### PR DESCRIPTION
The zip dependency is only used for DMARC report parsing and hence unnecessary when not using that. The main goal of getting rid of it is that cargo deny finds a BSL library when using mail-auth:
```
error[rejected]: failed to satisfy license requirements
  ┌─ registry+https://github.com/rust-lang/crates.io-index#lockfree-object-pool@0.1.6:4:12
  │
4 │ license = "BSL-1.0"
  │            ━━━━━━━
  │            │
  │            license expression retrieved via Cargo.toml `license`
  │            rejected: license is not explicitly allowed
  │
  ├ BSL-1.0 - Boost Software License 1.0:
  ├   - OSI approved
  ├   - FSF Free/Libre
  ├ lockfree-object-pool v0.1.6
    └── zopfli v0.8.1
        └── zip v2.5.0
            └── mail-auth v0.6.1
```