### PR TITLE
Fix feature unification conflict for quick-xml-depending crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ ed25519-dalek = { version = "2.0", optional = true }
 flate2 = "1.0.25"
 mail-parser = { version = "0.11", features = ["full_encoding"] }
 mail-builder = { version = "0.4" }
-quick-xml = { version = "0.37", optional = true }
+quick-xml = { version = "0.37", features = ["encoding"], optional = true }
 ring = { version = "0.17", optional = true }
 rsa = { version = "0.9.8", optional = true }
 rustls-pemfile = { version = "2", optional = true }

--- a/src/report/dmarc/parse.rs
+++ b/src/report/dmarc/parse.rs
@@ -304,17 +304,18 @@ impl Extension {
         buf: &mut Vec<u8>,
         extensions: &mut Vec<Extension>,
     ) -> Result<(), String> {
+        let decoder = reader.decoder();
         while let Some(tag) = reader.next_tag(buf)? {
             match tag.name().as_ref() {
                 b"extension" => {
                     let mut e = Extension::default();
                     if let Ok(Some(attr)) = tag.try_get_attribute("name") {
-                        if let Ok(attr) = attr.unescape_value() {
+                        if let Ok(attr) = attr.decode_and_unescape_value(decoder) {
                             e.name = attr.to_string();
                         }
                     }
                     if let Ok(Some(attr)) = tag.try_get_attribute("definition") {
-                        if let Ok(attr) = attr.unescape_value() {
+                        if let Ok(attr) = attr.decode_and_unescape_value(decoder) {
                             e.definition = attr.to_string();
                         }
                     }


### PR DESCRIPTION
`mail-auth` should use `decode_and_unescape_value` instead of `unescape_value`. See [related issue](https://github.com/stalwartlabs/mail-auth/issues/41).

Closes #41.