### PR TITLE
Remove `encoding` feature for `quick-xml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ ed25519-dalek = { version = "2.0", optional = true }
 flate2 = "1.0.25"
 mail-parser = { version = "0.11", features = ["full_encoding"] }
 mail-builder = { version = "0.4" }
-quick-xml = { version = "0.37", features = ["encoding"], optional = true }
+quick-xml = { version = "0.37", optional = true }
 ring = { version = "0.17", optional = true }
 rsa = { version = "0.9.8", optional = true }
 rustls-pemfile = { version = "2", optional = true }


### PR DESCRIPTION
As discussed in [this thread](https://github.com/stalwartlabs/mail-auth/pull/42#discussion_r2084749272), the `encoding` feature of `quick-xml` should not be enabled by default. This avoids including a large lib in cases it is not needed.