### PR TITLE
Ip Reverse does not take host into account

### DIFF
--- a/examples/iprev_verify.rs
+++ b/examples/iprev_verify.rs
@@ -1,0 +1,37 @@
+use std::{net::IpAddr, str::FromStr, sync::Arc};
+
+use mail_auth::{IprevResult, MessageAuthenticator, Parameters};
+
+/*
+ * SPDX-FileCopyrightText: 2020 Stalwart Labs LLC <hello@stalw.art>
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#[tokio::main]
+async fn main() {
+    // Create an authenticator using Cloudflare DNS
+    let authenticator = MessageAuthenticator::new_cloudflare().unwrap();
+    //Letsencrypt IP
+    let ip = IpAddr::from_str("54.215.62.21").unwrap();
+    // Verify IPREV identity
+    let result = authenticator
+        .verify_iprev(Parameters::new(ip))
+        .await;
+    assert_eq!(result.result,IprevResult::Pass);
+    assert_eq!(result.ptr,Some(Arc::new(vec!["ec2-54-215-62-21.us-west-1.compute.amazonaws.com.".to_string()])));
+    //Fake letsencrypt IP
+    let ip = IpAddr::from_str("8.8.8.8").unwrap();
+    // Verify IPREV identity
+    let result = authenticator
+        .verify_iprev(Parameters::new(ip))
+        .await;
+    assert_eq!(result.result,IprevResult::Pass);
+    assert_ne!(result.ptr,Some(Arc::new(vec!["ec2-54-215-62-21.us-west-1.compute.amazonaws.com.".to_string()])));
+        //Fake letsencrypt IP
+    let ip = IpAddr::from_str("141.95.150.143").unwrap();
+    // Verify IPREV identity
+    let result = authenticator
+        .verify_iprev(Parameters::new(ip))
+        .await;
+    assert_ne!(result.result,IprevResult::Pass);
+}


### PR DESCRIPTION
Hello,

Thank you for this software.

On your [doc](https://stalw.art/docs/mta/authentication/iprev), you state:

> In reverse IP verification, the SMTP server performs a reverse lookup of the **connecting client's IP address to see if it matches the hostname provided by the client in the EHLO or HELO command**.

However, it only checks address -> hostname and hostname -> address matches (see my example), and not EHLO domain.

I think it would be better to change the doc to state only address is checked, not EHLO domain. Or to add a checkbox to allow Iprev to check also EHLO domain. However, it might be dangerous, for instance, Outlook sometimes helo with a different hostname:

<img width="1297" height="82" alt="image" src="https://github.com/user-attachments/assets/c0c75fa3-8f05-431b-b670-756c98e43ab3" />


Thank you.
