### PR TITLE
Disable unused zip compression backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ test = []
 rkyv = ["dep:rkyv", "mail-parser/rkyv"]
 
 [dependencies]
-ahash = "0.8.0"
 flate2 = "1.1"
 mail-parser = { version = "0.11", features = ["full_encoding"] }
 mail-builder = { version = "0.4" }
@@ -35,9 +34,8 @@ rustls-pki-types = "1.14"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 hickory-resolver = { version = "=0.26.0-alpha.1", features = ["tls-ring", "dnssec-ring"] }
-zip = { version = "6.0", optional = true }
+zip = { version = "6.0", optional = true, default-features = false, features = ["deflate-flate2"] }
 rand = { version = "0.8.5", optional = true }
-quick_cache = "0.6.9"
 rkyv = { version = "0.8", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
DMARC/TLS-RPT reports are meant to be compressed with GZIP according to the specs. Looks like only Google (?) follow their own approach of using zip files, compressed with deflate instead. So disabled the other zip backends.

This avoids pulling in heavy deps like `zlib`.

Also noticed some other unused deps here, so cleaned them up too.