### PR TITLE
Use body canonicalization for bh in non-streaming sign path

### DIFF
--- a/src/dkim/canonicalize.rs
+++ b/src/dkim/canonicalize.rs
@@ -317,7 +317,7 @@ impl Signature {
         let body = message.body();
         let body_len = body.len();
         let canonical_headers = self.ch.canonical_headers(headers);
-        let canonical_body = self.ch.canonical_body(body, u64::MAX);
+        let canonical_body = self.cb.canonical_body(body, u64::MAX);
 
         // Add any missing headers
         signed_headers.reverse();

--- a/src/dkim/sign.rs
+++ b/src/dkim/sign.rs
@@ -176,6 +176,62 @@ pub mod test {
         );
     }
 
+    #[test]
+    fn sign_uses_body_canonicalization_for_bh() {
+        // A body whose relaxed and simple canonicalizations differ.
+        let message = concat!(
+            "From: a@example.com\r\n",
+            "To: b@example.com\r\n",
+            "Subject: t\r\n",
+            "Date: Mon, 01 Jan 2024 00:00:00 +0000\r\n",
+            "Message-ID: <t@example.com>\r\n",
+            "\r\n",
+            "Line   with   spaces\r\n",
+            "Trailing tabs\t\t\r\n",
+            "\r\n",
+            "\r\n",
+        );
+
+        let sign = |ch, cb| {
+            let pk = RsaKey::<Sha256>::from_key_der(PrivateKeyDer::Pkcs1(
+                PrivatePkcs1KeyDer::from_pem_slice(RSA_PRIVATE_KEY.as_bytes()).unwrap(),
+            ))
+            .unwrap();
+            DkimSigner::from_key(pk)
+                .domain("example.com")
+                .selector("test")
+                .headers(["From", "To", "Subject", "Date", "Message-ID"])
+                .header_canonicalization(ch)
+                .body_canonicalization(cb)
+                .sign(message.as_bytes())
+                .unwrap()
+                .bh
+        };
+
+        let bh_rr = sign(Canonicalization::Relaxed, Canonicalization::Relaxed);
+        let bh_rs = sign(Canonicalization::Relaxed, Canonicalization::Simple);
+        let bh_sr = sign(Canonicalization::Simple, Canonicalization::Relaxed);
+        let bh_ss = sign(Canonicalization::Simple, Canonicalization::Simple);
+
+        // bh must track BODY canonicalization, not header canonicalization.
+        assert_eq!(
+            bh_rr, bh_sr,
+            "bh must be equal when body canon is equal (both relaxed)"
+        );
+        assert_eq!(
+            bh_rs, bh_ss,
+            "bh must be equal when body canon is equal (both simple)"
+        );
+        assert_ne!(
+            bh_rr, bh_rs,
+            "bh must differ when body canon differs (relaxed vs simple)"
+        );
+        assert_ne!(
+            bh_sr, bh_ss,
+            "bh must differ when body canon differs (relaxed vs simple)"
+        );
+    }
+
     #[tokio::test]
     async fn dkim_sign_verify() {
         use crate::common::cache::test::DummyCaches;


### PR DESCRIPTION
Hi! I think I spotted a bug here, but I don't write Rust day-to-day and I don't know the project, so please push back if I've misread something.

In `Signature::canonicalize` (`src/dkim/canonicalize.rs`), the body gets canonicalized with `self.ch` (the header canonicalization) instead of `self.cb` (the body canonicalization):

```rust
let canonical_headers = self.ch.canonical_headers(headers);
let canonical_body = self.ch.canonical_body(body, u64::MAX);  // incorrectly uses ch, should be cb
```

Everywhere else `ch` and `cb` look like they're used consistently as header/body:

- the `c=` tag is rendered as `<ch>/<cb>` in `src/dkim/headers.rs`,
- the parser reads `c=A/B` into `ch=A, cb=B` in `src/dkim/parse.rs`,
- the verifier looks up the body hash by `signature.cb` in `src/dkim/verify.rs`,
- the streaming sign path uses `self.template.cb` in `src/dkim/streaming.rs`.

So when `ch == cb` (`relaxed/relaxed`, which from what I gather is what almost everyone uses) the line is harmless, but when they differ (`c=relaxed/simple` or `c=simple/relaxed`), `bh` ends up hashed with the wrong canonicalization, and the signature doesn't verify (including against this crate's own verifier, which uses `cb`).

I also added a test that would have caught this in `src/dkim/sign.rs`.