### PR TITLE
Depend on mail-parser 0.11.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rkyv = ["dep:rkyv", "mail-parser/rkyv"]
 
 [dependencies]
 flate2 = "1.1"
-mail-parser = { version = "0.11", features = ["full_encoding"] }
+mail-parser = { version = "0.11.5", features = ["full_encoding"] }
 quick-xml = { version = "0.41", optional = true }
 hashify =  { version = "0.2" }
 aws-lc-rs = { version = "1", optional = true }

--- a/src/common/headers.rs
+++ b/src/common/headers.rs
@@ -185,7 +185,7 @@ impl<'x> Iterator for HeaderIterator<'x> {
                         } else if self
                             .iter
                             .peek()
-                            .is_none_or(|(_, next_byte)| ![b' ', b'\t'].contains(next_byte))
+                            .is_none_or(|(_, next_byte)| !b" \t".contains(next_byte))
                         {
                             // Invalid header, return anyway.
                             let header_name = self
@@ -202,7 +202,7 @@ impl<'x> Iterator for HeaderIterator<'x> {
                 && self
                     .iter
                     .peek()
-                    .is_none_or(|(_, next_byte)| ![b' ', b'\t'].contains(next_byte))
+                    .is_none_or(|(_, next_byte)| !b" \t".contains(next_byte))
             {
                 let header_name = self
                     .message
@@ -272,7 +272,7 @@ impl<'x> Iterator for HeaderParser<'x> {
                         } else if self
                             .iter
                             .peek()
-                            .is_none_or(|(_, next_byte)| ![b' ', b'\t'].contains(next_byte))
+                            .is_none_or(|(_, next_byte)| !b" \t".contains(next_byte))
                         {
                             // Invalid header, return anyway.
                             let header_name = self
@@ -314,7 +314,7 @@ impl<'x> Iterator for HeaderParser<'x> {
                 && self
                     .iter
                     .peek()
-                    .is_none_or(|(_, next_byte)| ![b' ', b'\t'].contains(next_byte))
+                    .is_none_or(|(_, next_byte)| !b" \t".contains(next_byte))
             {
                 let header_name = self
                     .message

--- a/src/dkim/canonicalize.rs
+++ b/src/dkim/canonicalize.rs
@@ -241,7 +241,7 @@ impl Canonicalization {
 
                     for &ch in value {
                         if !ch.is_ascii_whitespace() {
-                            if [b' ', b'\t'].contains(&last_ch) && bw > 0 {
+                            if b" \t".contains(&last_ch) && bw > 0 {
                                 hasher.write_len(b" ", &mut bw);
                             }
                             hasher.write_len(&[ch], &mut bw);

--- a/src/dkim2/parse.rs
+++ b/src/dkim2/parse.rs
@@ -248,11 +248,8 @@ mod test {
         )
         .as_bytes();
 
-        let from_parsed = AuthenticatedMessage::from_parsed(
-            &MessageParser::new().parse(raw).unwrap(),
-            raw,
-            true,
-        );
+        let from_parsed =
+            AuthenticatedMessage::from_parsed(&MessageParser::new().parse(raw).unwrap(), raw, true);
         assert_eq!(from_parsed.dkim2_signatures.len(), 1);
         assert_eq!(from_parsed.dkim2_instances.len(), 1);
 

--- a/src/report/dmarc/generate.rs
+++ b/src/report/dmarc/generate.rs
@@ -158,24 +158,24 @@ impl PolicyPublished {
     pub(crate) fn to_xml(&self, xml: &mut String) {
         writeln!(xml, "\t<policy_published>").ok();
         writeln!(xml, "\t\t<domain>{}</domain>", escape_xml(&self.domain)).ok();
-        writeln!(xml, "\t\t<p>{}</p>", &self.p).ok();
+        writeln!(xml, "\t\t<p>{}</p>", self.p).ok();
         if self.sp != Disposition::Unspecified {
-            writeln!(xml, "\t\t<sp>{}</sp>", &self.sp).ok();
+            writeln!(xml, "\t\t<sp>{}</sp>", self.sp).ok();
         }
         if self.np != Disposition::Unspecified {
-            writeln!(xml, "\t\t<np>{}</np>", &self.np).ok();
+            writeln!(xml, "\t\t<np>{}</np>", self.np).ok();
         }
         if self.adkim != Alignment::Unspecified {
-            writeln!(xml, "\t\t<adkim>{}</adkim>", &self.adkim).ok();
+            writeln!(xml, "\t\t<adkim>{}</adkim>", self.adkim).ok();
         }
         if self.aspf != Alignment::Unspecified {
-            writeln!(xml, "\t\t<aspf>{}</aspf>", &self.aspf).ok();
+            writeln!(xml, "\t\t<aspf>{}</aspf>", self.aspf).ok();
         }
         if self.discovery_method != Discovery::Unspecified {
             writeln!(
                 xml,
                 "\t\t<discovery_method>{}</discovery_method>",
-                &self.discovery_method
+                self.discovery_method
             )
             .ok();
         }
@@ -436,7 +436,7 @@ impl Display for SpfResult {
 
 fn escape_xml(text: &str) -> Cow<'_, str> {
     for ch in text.as_bytes() {
-        if [b'"', b'\'', b'<', b'>', b'&'].contains(ch) {
+        if b"\"'<>&".contains(ch) {
             let mut escaped = String::with_capacity(text.len());
             for ch in text.chars() {
                 match ch {

--- a/src/spf/macros.rs
+++ b/src/spf/macros.rs
@@ -209,7 +209,7 @@ fn add_part(result: &mut Vec<u8>, part: &[u8], pos: usize, escape: bool) {
         result.extend_from_slice(part);
     } else {
         for ch in part {
-            if ch.is_ascii_alphanumeric() || [b'-', b'.', b'_', b'~'].contains(ch) {
+            if ch.is_ascii_alphanumeric() || b"-._~".contains(ch) {
                 result.push(*ch);
             } else {
                 result.extend_from_slice(format!("%{ch:02x}").as_bytes());


### PR DESCRIPTION
Otherwise compilation fails due to missing `HeaderName::DkimSignature2`.

(Note that the Cargo team [now recommends](https://blog.rust-lang.org/2023/08/29/committing-lockfiles/) versioning `Cargo.lock`.)